### PR TITLE
Fix - cache expiry never clearing cache

### DIFF
--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/APIClient.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/APIClient.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.dp.authorisation.permissions;
 
-import com.github.onsdigital.dp.authorisation.exceptions.BundleNotCached;
 import com.github.onsdigital.dp.authorisation.exceptions.Messages;
 import com.github.onsdigital.dp.authorisation.permissions.models.Bundle;
 import com.google.gson.Gson;
@@ -45,7 +44,7 @@ public class APIClient implements Store {
      * @return getResponseEntity
      * @throws Exception
      */
-    public Bundle getPermissionsBundle() throws BundleNotCached {
+    public Bundle getPermissionsBundle() throws Exception {
         String uri = host + bundlerEndpoint;
         info().data("uri", uri).log("getPermissionsBundle: starting permissions bundle request");
 
@@ -68,8 +67,6 @@ public class APIClient implements Store {
         } catch (ClientProtocolException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
@@ -66,6 +66,10 @@ public class CachingStore implements Cache {
         }
     }
 
+    public void setPermissionsBundle(Bundle permissionsBundle) {
+        this.cachedBundle = permissionsBundle;
+    }
+
     /**
      * startExpiryChecker starts a goroutine to continually check for expired cache data.
      *
@@ -79,25 +83,6 @@ public class CachingStore implements Cache {
         );
     }
 
-//    /**
-//     * checkCacheExpiry clears the cache data it it's gone beyond it's expiry time.
-//     *
-//     * @param maxCacheTime
-//     */
-//    void checkCacheExpiry(Duration maxCacheTime) {
-//        mutex.lock();
-//        try {
-//            if (lastUpdated != null  && (lastUpdated.getMillis()
-//                    - System.currentTimeMillis()) > maxCacheTime.getMillis()) {
-//                info().log("clearing permissions cache data as it has gone beyond the max cache time");
-//                cachedBundle = null;
-//                setLastUpdated(new DateTime());
-//            }
-//        } finally {
-//            mutex.unlock();
-//        }
-//    }
-
     /**
      * checkCacheExpiry clears the cache data it it's gone beyond it's expiry time.
      *
@@ -107,7 +92,7 @@ public class CachingStore implements Cache {
         mutex.lock();
         try {
             if (lastUpdated != null) {
-                if ((lastUpdated.getMillis() - System.currentTimeMillis()) > maxCacheTime.getMillis()) {
+                if ((System.currentTimeMillis() - lastUpdated.getMillis()) > maxCacheTime.getMillis()) {
                     info().log("clearing permissions cache data as it has gone beyond the max cache time");
                     cachedBundle = null;
                     setLastUpdated(new DateTime());

--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
@@ -79,6 +79,25 @@ public class CachingStore implements Cache {
         );
     }
 
+//    /**
+//     * checkCacheExpiry clears the cache data it it's gone beyond it's expiry time.
+//     *
+//     * @param maxCacheTime
+//     */
+//    void checkCacheExpiry(Duration maxCacheTime) {
+//        mutex.lock();
+//        try {
+//            if (lastUpdated != null  && (lastUpdated.getMillis()
+//                    - System.currentTimeMillis()) > maxCacheTime.getMillis()) {
+//                info().log("clearing permissions cache data as it has gone beyond the max cache time");
+//                cachedBundle = null;
+//                setLastUpdated(new DateTime());
+//            }
+//        } finally {
+//            mutex.unlock();
+//        }
+//    }
+
     /**
      * checkCacheExpiry clears the cache data it it's gone beyond it's expiry time.
      *
@@ -87,10 +106,13 @@ public class CachingStore implements Cache {
     void checkCacheExpiry(Duration maxCacheTime) {
         mutex.lock();
         try {
-            if (lastUpdated != null  && (lastUpdated.getMillis()
-                    - System.currentTimeMillis()) > maxCacheTime.getMillis()) {
-                info().log("clearing permissions cache data as it has gone beyond the max cache time");
-                cachedBundle = null;
+            if (lastUpdated != null) {
+                if ((lastUpdated.getMillis() - System.currentTimeMillis()) > maxCacheTime.getMillis()) {
+                    info().log("clearing permissions cache data as it has gone beyond the max cache time");
+                    cachedBundle = null;
+                    setLastUpdated(new DateTime());
+                }
+            } else {
                 setLastUpdated(new DateTime());
             }
         } finally {

--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
@@ -89,7 +89,7 @@ public class CachingStore implements Cache {
     }
 
     /**
-     * checkCacheExpiry clears the cache data if it's gone beyond it's expiry time.
+     * checkCacheExpiry clears the cache data if the current time is past the expiry time.
      *
      * @param maxCacheTime
      */

--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
@@ -67,7 +67,7 @@ public class CachingStore implements Cache {
     }
 
     /**
-     * setPermissionsBundle sets the value of cachedBundle
+     * setPermissionsBundle sets the value of Bundle cachedBundle.
      *
      * @param permissionsBundle - the value to set the cachedBundle to
      */

--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
@@ -66,6 +66,11 @@ public class CachingStore implements Cache {
         }
     }
 
+    /**
+     * setPermissionsBundle sets the value of cachedBundle
+     *
+     * @param permissionsBundle - the value to set the cachedBundle to
+     */
     public void setPermissionsBundle(Bundle permissionsBundle) {
         this.cachedBundle = permissionsBundle;
     }
@@ -84,7 +89,7 @@ public class CachingStore implements Cache {
     }
 
     /**
-     * checkCacheExpiry clears the cache data it it's gone beyond it's expiry time.
+     * checkCacheExpiry clears the cache data if it's gone beyond it's expiry time.
      *
      * @param maxCacheTime
      */

--- a/src/test/java/com/github/onsdigital/dp/authorisation/permissions/APIClientTest.java
+++ b/src/test/java/com/github/onsdigital/dp/authorisation/permissions/APIClientTest.java
@@ -85,7 +85,7 @@ public class APIClientTest {
 
             client.getPermissionsBundle();
         } catch (Exception ex) {
-            assertThat(ex.getMessage(), CoreMatchers.equalTo("java.lang.Exception: unexpected status returned from the permissions api permissions-bundle endpoint: 400"));
+            assertThat(ex.getMessage(), CoreMatchers.equalTo("unexpected status returned from the permissions api permissions-bundle endpoint: 400"));
         }
     }
 }

--- a/src/test/java/com/github/onsdigital/dp/authorisation/permissions/CachingStoreTest.java
+++ b/src/test/java/com/github/onsdigital/dp/authorisation/permissions/CachingStoreTest.java
@@ -6,7 +6,6 @@ import com.github.onsdigital.dp.authorisation.exceptions.BundleNotCached;
 import org.hamcrest.CoreMatchers;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -15,7 +14,7 @@ import org.mockito.MockitoAnnotations;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 public class CachingStoreTest {
@@ -97,7 +96,7 @@ public class CachingStoreTest {
         // when getPermissionsBundle is called, a BundleNotCached exception is thrown.
         Exception exception = assertThrows(Exception.class,
                 () -> cachingStore.getPermissionsBundle());
-        Assert.assertTrue(exception.getMessage().contains(expectedBundleNotCachedMessage));
+        assertTrue(exception.getMessage().contains(expectedBundleNotCachedMessage));
     }
 
     @Test
@@ -112,10 +111,10 @@ public class CachingStoreTest {
         cachingStore.checkCacheExpiry(Duration.standardMinutes(1));
 
         // Then the cache is not updated and a permissions bundle still exists
-        Assert.assertNotNull(cachingStore.getPermissionsBundle());
+        assertNotNull(cachingStore.getPermissionsBundle());
 
         // And lastUpdated gets initialised
-        Assert.assertNotNull(cachingStore.getLastUpdated());
+        assertNotNull(cachingStore.getLastUpdated());
     }
 
     @Test
@@ -130,7 +129,7 @@ public class CachingStoreTest {
         cachingStore.checkCacheExpiry(Duration.standardMinutes(1));
 
         // Then the cache is not updated and a permissions bundle still exists
-        Assert.assertNotNull(cachingStore.getPermissionsBundle());
+        assertNotNull(cachingStore.getPermissionsBundle());
     }
 
     @Test


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
There is currently a bug that is preventing the cache from being cleared when the expiry time has passed.

The bug appears to be due to the following 2 things:

1. The lastUpdated DateTime value was not being initialised and therefore the check against it was always returning null, which prevented the cache from being cleared.
2. The time lapsed since lastUpdated, even if lastUpdated had been initialised, was being calculated incorrectly by subtracting the current time from the lastUpdated time, which would always result in a negative value. It needs to be the other way around.

These two problems have now been fixed in the checkCacheExpiry method. New unit tests have also been added and an old one replaced.

NB. Details are given in the bug ticket here: https://trello.com/c/mqfC1fna/1671-review-possible-bug-in-dp-authorisation-java

# How to review
<!--- Describe in detail how you tested your changes. -->
The unit tests can be run using this command: make test

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->

Anyone
