### PR TITLE
Fix/ensure updates happen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@ Authorize user:
 
 - Permissions check - the action that the user is taking will have a permission associated with it. The permissions
   check does a lookup to see if the requested permission is granted to the user, or the groups that the user belongs to.
-  This functionality is within the `permissions` package. See
-  the [package readme for more details](permissions/README.md)
+  This functionality is within the `permissions` package.
 
-### Usage
+## Usage
 
 The permission check can be checked within a handler with more complex logic if needed.
 
-#### Add authorisation within a handler
+### Add authorisation within a handler
 
 The service should parse the JWT token and the UserDataPayload that comes from the JWT could be stored in the request
 content for later use within the handler.
@@ -20,12 +19,11 @@ Once the JWT token is parsed into UserDataPayload, it can be passed to the permi
 has access. It's likely at this point that additional data will be needed by the permissions checker to make a decision.
 This is where the `attributes` parameter of the permissions checker is used - for example to set a collection ID:
 
-``` java 
-  String permission = "legacy.read";
+``` java
+  String permission = "legacy:read";
   HashMap<String, String> attributes = new HashMap<String, String>() {{
         put("collection_id", "collection768");
   }};
 
   Boolean hasPermission = permissionChecker.hasPermission(userDataPayload, permission, attributes);
-
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.20.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/CachingStore.java
@@ -76,14 +76,16 @@ public class CachingStore implements Cache {
     }
 
     /**
-     * startExpiryChecker starts a goroutine to continually check for expired cache data.
+     * startExpiryChecker starts a ScheduledFuture to continually check if the cache has expired.
      *
      * @param checkInterval - how often to check for expired cache data.
      * @param maxCacheTime  - how long to cache permissions data before it's expired.
      */
     public void startExpiryChecker(Duration checkInterval, Duration maxCacheTime) {
-        scheduledExecutorService.schedule(
+        // Don't run the expiry check immediately, to give the cache a chance to populate first. Run at the specified interval thereafter.
+        scheduledExecutorService.scheduleWithFixedDelay(
                 () -> checkCacheExpiry(maxCacheTime),
+                checkInterval.getMillis(),
                 checkInterval.getMillis(), TimeUnit.MILLISECONDS
         );
     }
@@ -111,15 +113,15 @@ public class CachingStore implements Cache {
     }
 
     /**
-     * startCacheUpdater starts a go routine to continually update cache data at time intervals.
+     * startCacheUpdater starts ScheduledFuture to continually update cache data at time intervals.
      *
      * @param updateInterval - how often to update the cache data.
      */
     public void startCacheUpdater(Duration updateInterval) {
-        update();
-        scheduledExecutorService.schedule(
+        // Update immediately, then at the specified interval thereafter.
+        scheduledExecutorService.scheduleWithFixedDelay(
                 () -> update(),
-                updateInterval.getMillis(), TimeUnit.MILLISECONDS
+                0, updateInterval.getMillis(), TimeUnit.MILLISECONDS
         );
     }
 
@@ -132,8 +134,8 @@ public class CachingStore implements Cache {
     public Bundle update() {
         mutex.lock();
         try {
+            info().log("getting latest permissions bundle");
             Bundle permissionsBundle = underlyingStore.getPermissionsBundle();
-            info().log("updating cache");
             cachedBundle = permissionsBundle;
             setLastUpdateSuccessful(true);
         } catch (Exception e) {

--- a/src/main/java/com/github/onsdigital/dp/authorisation/permissions/PermissionChecker.java
+++ b/src/main/java/com/github/onsdigital/dp/authorisation/permissions/PermissionChecker.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -34,6 +35,11 @@ public class PermissionChecker {
      */
     public PermissionChecker(String permissionsAPIHost, Duration cacheUpdateInterval,
             Duration expiryCheckInterval, Duration maxCacheTime) {
+        info()
+            .data("expiryCheckInterval", expiryCheckInterval.getStandardSeconds())
+            .data("cacheUpdateInterval", cacheUpdateInterval.getStandardSeconds())
+            .data("maxCacheTime", maxCacheTime.getStandardSeconds())
+            .log("starting PermissionChecker with provided configuration");
         CachingStore cachingStore = new CachingStore(new APIClient(permissionsAPIHost));
         cachingStore.startCacheUpdater(cacheUpdateInterval);
         cachingStore.startExpiryChecker(expiryCheckInterval, maxCacheTime);

--- a/src/test/java/com/github/onsdigital/dp/authorisation/permissions/CachingStoreTest.java
+++ b/src/test/java/com/github/onsdigital/dp/authorisation/permissions/CachingStoreTest.java
@@ -15,6 +15,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class CachingStoreTest {
@@ -149,9 +151,12 @@ public class CachingStoreTest {
         Bundle expected = new Bundle();
         when(permissionStore.getPermissionsBundle()).thenReturn(expected);
 
-        cachingStore.startCacheUpdater(Duration.standardSeconds(1));
-        cachingStore.startExpiryChecker(Duration.standardSeconds(2), Duration.standardMinutes(1));
+        cachingStore.startCacheUpdater(Duration.millis(50));
 
-        assertThat(cachingStore.getPermissionsBundle(), equalTo(expected));
+        try {
+            verify(permissionStore, timeout(500).atLeast(2)).getPermissionsBundle();
+        } finally {
+            cachingStore.close();
+        }
     }
 }


### PR DESCRIPTION
### What

Cache updates were not happening inside zebedee.

The `.schedule` command just runs once - you can see this in sandbox. 

I have switched this out to using scheduleWithFixedDelay - this ensures it will run every interval.

### How to review

You can see this happening with zebedee by:

- run legacy-core-publishing stack (including port forward to sandbox)
- follow zebedee's logs (`SERVICE=zebdee make logs LOGS_TAIL=1`) to see it update every 10 seconds - without this change it runs once on startup and then once after 10 seconds.

### Who can review

Not me. 